### PR TITLE
Support non-stack base nodes to be in the stack

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -38,16 +38,28 @@ go get github.com/xnslong/guess-stack/guess-pprof
 # 使用
 
 ```
-Usage of guess-pprof:
-  -d int
-        only fix stack with depth greater than (or equal to) the threshold, because only deep stack may be trimmed (default 1)
-  -i string
-        input file (default "-")
-  -o string
-        output file (default "-")
-  -overlap int
-        trustable overlap length. when the number of overlapping elements is less than the length, it's not considered trustable for guessing (default 5)
-  -v    show verbose info for debug
+usage: guess-pprof [-h|--help] [-i|--input "<value>"] [-o|--output "<value>"]
+                   [--overlap <integer>] [-d|--depth <integer>] [-b|--base
+                   <integer>] [-v|--verbose <integer>] [--version]
+
+                   to guess the missing root nodes for deep stacks, so that the
+                   stacks can align with each other again
+
+Arguments:
+
+  -h  --help     Print help information
+  -i  --input    input pprof file. "-" means read from the standard input
+                 stream. Default: -
+  -o  --output   output pprof file, "-" means write to the standard output
+                 stream. Default: -
+      --overlap  the minimal overlapping call node count. Default: 5
+  -d  --depth    the minimal depth of the stack who may be trimmed (the deep
+                 stacks still remains deep after trimmed). Default: 1
+  -b  --base     number of the base nodes always existing for all stacks (such
+                 as the process name), no matter whether the root call nodes
+                 are trimmed. Default: 0
+  -v  --verbose 
+      --version 
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,16 +43,28 @@ go get github.com/xnslong/guess-stack/guess-pprof
 # Usage
 
 ```
-Usage of guess-pprof:
-  -d int
-        only fix stack with depth greater than (or equal to) the threshold, because only deep stack may be trimmed (default 1)
-  -i string
-        input file (default "-")
-  -o string
-        output file (default "-")
-  -overlap int
-        trustable overlap length. when the number of overlapping elements is less than the length, it's not considered trustable for guessing (default 5)
-  -v    show verbose info for debug
+usage: guess-pprof [-h|--help] [-i|--input "<value>"] [-o|--output "<value>"]
+                   [--overlap <integer>] [-d|--depth <integer>] [-b|--base
+                   <integer>] [-v|--verbose <integer>] [--version]
+
+                   to guess the missing root nodes for deep stacks, so that the
+                   stacks can align with each other again
+
+Arguments:
+
+  -h  --help     Print help information
+  -i  --input    input pprof file. "-" means read from the standard input
+                 stream. Default: -
+  -o  --output   output pprof file, "-" means write to the standard output
+                 stream. Default: -
+      --overlap  the minimal overlapping call node count. Default: 5
+  -d  --depth    the minimal depth of the stack who may be trimmed (the deep
+                 stacks still remains deep after trimmed). Default: 1
+  -b  --base     number of the base nodes always existing for all stacks (such
+                 as the process name), no matter whether the root call nodes
+                 are trimmed. Default: 0
+  -v  --verbose 
+      --version 
 ```
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/google/pprof v0.0.0-20220218203455-0368bd9e19a7
 	github.com/stretchr/testify v1.7.0
 )
+
+require github.com/akamensky/argparse v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/akamensky/argparse v1.3.1 h1:kP6+OyvR0fuBH6UhbE6yh/nskrDEIQgEA1SUXDPjx4g=
+github.com/akamensky/argparse v1.3.1/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz4IZQuw64xA=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/guess-pprof/profile_stacktrace.go
+++ b/guess-pprof/profile_stacktrace.go
@@ -38,6 +38,7 @@ func (l *StackTraceElement) EqualsTo(another fix.StackNode) bool {
 }
 
 type StackTrace struct {
+	Root     []*StackTraceElement
 	Elements []*StackTraceElement
 }
 
@@ -76,8 +77,9 @@ func reverse(elements []*StackTraceElement) {
 }
 
 func StackTraceToSample(st *StackTrace, target *profile.Sample) {
-	elem := make([]*StackTraceElement, len(st.Elements))
-	copy(elem, st.Elements)
+	elem := make([]*StackTraceElement, len(st.Elements)+len(st.Root))
+	copy(elem, st.Root)
+	copy(elem[len(st.Root):], st.Elements)
 
 	reverse(elem)
 
@@ -90,13 +92,17 @@ func StackTraceToSample(st *StackTrace, target *profile.Sample) {
 	target.Location = loc
 }
 
-func SampleToStackTrace(sample *profile.Sample) *StackTrace {
+func SampleToStackTrace(sample *profile.Sample, rootCount int) *StackTrace {
 	var v []*StackTraceElement
 	for _, location := range sample.Location {
 		v = append(v, &StackTraceElement{location})
 	}
 
 	reverse(v)
-	st := &StackTrace{v}
+
+	r := v[:rootCount]
+	s := v[rootCount:]
+
+	st := &StackTrace{Root: r, Elements: s}
 	return st
 }


### PR DESCRIPTION
The stacks may contain base nodes, which are not real nodes in the call stack (such as the process name), and always exist in the bottom of every stack whether if the root nodes may be trimmed. 

Suppose `e1` is a base node in the following stack, and `e2` is the real root node.

```
S1 = [ e1, e2, e3, e4, e5 ]
```

and if 2 root nodes are trimmed, then the stack will become

```
S1 = [ e1, e4, e5 ] // with e2, e3 trimmed, and e1 will always be preserved
```

So they will disturb fixing the graph.

Here, by adding a `--base <int>` argument, telling the actual root is from the `i`-th node from the stacks, and we need to fix stacks of nodes upside of the node.