### PR TITLE
compute joints with prefix tree (trie) to reduce complexity from O(n^2) to O(n)

### DIFF
--- a/core/guess/guess_fixer.go
+++ b/core/guess/guess_fixer.go
@@ -2,10 +2,8 @@ package guess
 
 import (
 	"sort"
-	"sync"
 
 	"github.com/xnslong/guess-stack/core/interfaces"
-	"github.com/xnslong/guess-stack/utils"
 )
 
 type CommonRootFixer struct {
@@ -120,21 +118,16 @@ func updateRootForGroup(computePaths []*computePath, root []interfaces.StackNode
 }
 
 func computeJoints(paths []*computePath) {
-	p := utils.NewPool(100)
+	var stacks []interfaces.Stack
+	var joints []*joint
 
-	wg := &sync.WaitGroup{}
 	for _, path := range paths {
-		wg.Add(1)
-		p0 := path
-
-		p.Submit(func() {
-			computeJoint(p0, paths)
-			wg.Done()
-		})
+		stacks = append(stacks, path.Stack)
+		joints = append(joints, path.joint)
 	}
-	p.Close()
 
-	wg.Wait()
+	transformedStacks := transform(stacks)
+	computeStackJoints(transformedStacks, joints)
 }
 
 func computeJoint(path *computePath, stacks []*computePath) {

--- a/core/guess/trie.go
+++ b/core/guess/trie.go
@@ -1,0 +1,177 @@
+package guess
+
+import "github.com/xnslong/guess-stack/core/interfaces"
+
+type stackNode struct {
+	interfaces.StackNode
+}
+
+type stack struct {
+	path    []*stackNode
+	index   int
+	needFix bool
+}
+
+var nodes = make(map[int][]*stackNode)
+
+func intern(node interfaces.StackNode) *stackNode {
+	hash := node.HashCode()
+
+	hashNodes := nodes[hash]
+	for _, hashNode := range hashNodes {
+		if hashNode.EqualsTo(node) {
+			return hashNode
+		}
+	}
+
+	n := &stackNode{StackNode: node}
+	nodes[hash] = append(nodes[hash], n)
+	return n
+}
+
+func transform(stacks []interfaces.Stack) []*stack {
+	result := make([]*stack, len(stacks))
+
+	for i, s := range stacks {
+		path := s.Path()
+
+		stackNodes := make([]*stackNode, 0, len(path))
+		for _, node := range path {
+			n := intern(node)
+			stackNodes = append(stackNodes, n)
+		}
+
+		result[i] = &stack{
+			path:    stackNodes,
+			index:   i,
+			needFix: s.NeedFix(),
+		}
+	}
+
+	return result
+}
+
+type node struct {
+	Parent    *node
+	StackNode *stackNode
+	Children  map[*stackNode]*node
+
+	MyIndex     int
+	JoinPathIdx int
+	JoinNodeIdx int
+	Overlaps    int
+}
+
+func (n *node) visitLeaf(f func(leaf *node)) {
+	if len(n.Children) == 0 {
+		f(n)
+		return
+	}
+
+	for _, child := range n.Children {
+		child.visitLeaf(f)
+	}
+}
+
+func buildTrie(stacks []*stack) *node {
+	root := &node{
+		Parent:    nil,
+		StackNode: nil,
+		Children:  make(map[*stackNode]*node),
+	}
+
+	for _, s := range stacks {
+		if s.needFix {
+			addStack(s, root)
+		}
+	}
+
+	return root
+}
+
+func addStack(stack *stack, root *node) {
+	current := root
+
+	path := stack.path
+
+	for len(path) > 0 {
+		me := path[0]
+		path = path[1:]
+		next, ok := current.Children[me]
+		if !ok {
+			next = &node{
+				Parent:    current,
+				StackNode: me,
+				Children:  make(map[*stackNode]*node),
+			}
+			current.Children[me] = next
+		}
+		current = next
+	}
+
+	current.MyIndex = stack.index
+}
+
+func computeStackJoints(stacks []*stack, joints []*joint) {
+	trie := buildTrie(stacks)
+
+	for i, s := range stacks {
+		compare(trie, i, s)
+	}
+
+	collectJoints(trie, joints)
+}
+
+func collectJoints(trie *node, joints []*joint) {
+	trie.visitLeaf(func(leaf *node) {
+		idx := leaf.MyIndex
+		n := leaf
+		for n != nil && n.Overlaps == 0 {
+			n = n.Parent
+		}
+		if n != nil {
+			joints[idx].Overlaps = n.Overlaps
+			joints[idx].JoinNodeIdx = n.JoinNodeIdx
+			joints[idx].JoinPathIdx = n.JoinPathIdx
+		}
+	})
+}
+
+func compare(trie *node, iStack int, s *stack) {
+	path := s.path
+
+	for len(path) > 0 {
+		updateOverlaps(trie, iStack, path)
+		path = path[1:]
+	}
+}
+
+func updateOverlaps(trie *node, iStack int, path []*stackNode) {
+	if len(path) == 0 {
+		return
+	}
+
+	path = path[1:]
+	start := len(path)
+
+	overlap := 0
+
+	for len(path) > 0 {
+		n := path[0]
+		path = path[1:]
+
+		next, ok := trie.Children[n]
+		if !ok {
+			break
+		}
+
+		overlap++
+		if next.Overlaps < overlap {
+			next.Overlaps = overlap
+			next.JoinPathIdx = iStack
+			next.JoinNodeIdx = start
+		}
+
+		trie = next
+	}
+}

--- a/core/interfaces/profile.go
+++ b/core/interfaces/profile.go
@@ -8,6 +8,7 @@ type StackFixer interface {
 
 type StackNode interface {
 	EqualsTo(another StackNode) bool
+	HashCode() int
 }
 
 type Stack interface {

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -8,6 +8,10 @@ import (
 
 type IntNode int
 
+func (i IntNode) HashCode() int {
+	return int(i)
+}
+
 func (i IntNode) EqualsTo(another interfaces.StackNode) bool {
 	return i == another
 }

--- a/guess-fold/folded.go
+++ b/guess-fold/folded.go
@@ -11,6 +11,14 @@ import (
 
 type stackElement string
 
+func (s stackElement) HashCode() int {
+	r := 0
+	for _, v := range s {
+		r = r*31 + int(v)
+	}
+	return r
+}
+
 func (s stackElement) EqualsTo(another interfaces.StackNode) bool {
 	se, ok := another.(stackElement)
 	if !ok {

--- a/guess-pprof/profile_stacktrace.go
+++ b/guess-pprof/profile_stacktrace.go
@@ -5,13 +5,9 @@ import (
 	"io"
 
 	"github.com/google/pprof/profile"
+
 	"github.com/xnslong/guess-stack/core/interfaces"
 )
-
-type StackTraceElement struct {
-	*profile.Location
-	name *nameStruct
-}
 
 type nameStruct struct {
 	Value string
@@ -28,6 +24,24 @@ func nameOf(name string) *nameStruct {
 	val = &nameStruct{name}
 	names[name] = val
 	return val
+}
+
+type StackTraceElement struct {
+	*profile.Location
+	name *nameStruct
+}
+
+func (l *StackTraceElement) HashCode() int {
+	if l.name == nil {
+		return 0
+	}
+
+	r := 0
+	for _, v := range l.name.Value {
+		r = r*31 + int(v)
+	}
+
+	return r
 }
 
 func NewStackTraceElement(location *profile.Location) *StackTraceElement {

--- a/utils/self_pprof.go
+++ b/utils/self_pprof.go
@@ -1,15 +1,35 @@
 package utils
 
 import (
+	"log"
 	"os"
+	"os/signal"
 	"runtime/pprof"
+	"syscall"
 )
 
 func DoWithPProf(outfile string, job func()) {
 	file, _ := os.OpenFile(outfile, os.O_CREATE|os.O_WRONLY, 0644)
-	defer file.Close()
+	defer func() {
+		file.Close()
+		log.Printf("self pprof is sampled to %s", outfile)
+	}()
 	pprof.StartCPUProfile(file)
 	defer pprof.StopCPUProfile()
 
-	job()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		job()
+	}()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+	select {
+	case sig := <-signals:
+		log.Printf("interrupted by %s", sig)
+	case <-done:
+	}
+
+	return
 }


### PR DESCRIPTION
# Improvement Result

before (v1.0.4):

```
2022/03/26 09:55:27 read profile success from: test_20220319_7b05e5.pprof.gz.proto
2022/03/26 09:56:07 fixed stacks: 9706/19605 (40.156s elapsed)
2022/03/26 09:56:10 write profile success to: test_20220319_7b05e5.out-2.pprof
```

after (new)

```
2022/03/26 09:55:18 read profile success from: test_20220319_7b05e5.pprof.gz.proto
2022/03/26 09:55:19 fixed stacks: 9706/19605 (732ms elapsed)
2022/03/26 09:55:22 write profile success to: test_20220319_7b05e5.out-2.pprof
2022/03/26 09:55:22 self pprof is sampled to test_20220319_7b05e5.self.pprof
```

# Improvement

Before, we need to compute the overlaps from any stack to all other stacks. Suppose we have n stacks, then there will be `n * (n-1)` runs of comparison. Complexity: `O(n^2)`

Now we gather all stacks to a prefix tree. Then when we compare a stack with the prefix tree. we can compare for all stack in the prefix tree with a run of comparison. So only `n` runs of comparison is required. Complexity: `O(n)`