### PR TITLE
fix bugs in trie & improve code structure for decorators

### DIFF
--- a/core/fix.go
+++ b/core/fix.go
@@ -37,9 +37,6 @@ func Fix(p interfaces.Profile, option FixOption) {
 
 func buildFixer(option FixOption) interfaces.StackFixer {
 	var middle []FixerDecorator
-	if option.MinDepth > 0 {
-		middle = append(middle, &FixDeeperStacksDecorator{&option})
-	}
 
 	if option.Verbose > 0 {
 		middle = append(middle, &ShowFixInfoDecorator{&option})
@@ -49,8 +46,13 @@ func buildFixer(option FixOption) interfaces.StackFixer {
 		middle = append(middle, &WithBaseDecorator{&option})
 	}
 
+	if option.MinDepth > 0 {
+		middle = append(middle, &FixDeeperStacksDecorator{&option})
+	}
+
 	var fixer interfaces.StackFixer = &guess.CommonRootFixer{MinOverlaps: option.Overlap}
-	for _, m := range middle {
+	for i := len(middle) - 1; i >= 0; i-- {
+		m := middle[i]
 		fixer = m.Decorate(fixer)
 	}
 	return fixer

--- a/core/fix.go
+++ b/core/fix.go
@@ -41,12 +41,12 @@ func buildFixer(option FixOption) interfaces.StackFixer {
 		middle = append(middle, &FixDeeperStacksDecorator{&option})
 	}
 
-	if option.BaseCount > 0 {
-		middle = append(middle, &WithBaseDecorator{&option})
-	}
-
 	if option.Verbose > 0 {
 		middle = append(middle, &ShowFixInfoDecorator{&option})
+	}
+
+	if option.BaseCount > 0 {
+		middle = append(middle, &WithBaseDecorator{&option})
 	}
 
 	var fixer interfaces.StackFixer = &guess.CommonRootFixer{MinOverlaps: option.Overlap}
@@ -124,68 +124,61 @@ func (s substack) EqualTo(another substack) bool {
 }
 
 type groups struct {
-	G     []substack
-	Count []int
+	Base   []substack
+	Groups [][]interfaces.Stack
 }
 
-func (g *groups) intern(s substack) (group int) {
-	defer func() {
-		if len(g.Count) < len(s)+1 {
-			newArr := make([]int, len(s)+1)
-			copy(newArr, g.Count)
-			g.Count = newArr
-		}
-		g.Count[len(s)]++
-	}()
+func (g *groups) intern(base substack, stack interfaces.Stack) {
 
-	for i, s2 := range g.G {
+	i := g.findGroupId(base)
+	if i < 0 {
+		g.Base = append(g.Base, base)
+		g.Groups = append(g.Groups, nil)
+		i = len(g.Base) - 1
+	}
+
+	g.Groups[i] = append(g.Groups[i], stack)
+	return
+}
+
+func (g *groups) findGroupId(s substack) int {
+	for i, s2 := range g.Base {
 		if s2.EqualTo(s) {
 			return i
 		}
 	}
-
-	g.G = append(g.G, s)
-	return len(g.G) - 1
+	return -1
 }
 
 func (f *WithBaseDecorator) Decorate(underlying interfaces.StackFixer) interfaces.StackFixer {
 	return fixerFunc(func(stacks []interfaces.Stack) {
 		g := &groups{}
-		base := make([][]interfaces.StackNode, len(stacks))
-		for i, stack := range stacks {
+		for _, stack := range stacks {
 			path := stack.Path()
 			b := utils.MinInt(f.BaseCount, len(path))
-
-			base[i] = path[:b]
 			stack.SetPath(path[b:])
-
-			gId := g.intern(base[i])
-			stack.SetGroup(gId)
+			g.intern(path[:b], stack)
 		}
 
 		f.logBaseInfo(g)
 
-		underlying.Fix(stacks)
+		for i, group := range g.Groups {
+			underlying.Fix(group)
+			base := g.Base[i]
 
-		for i, stack := range stacks {
-			path := stack.Path()
-			np := make([]interfaces.StackNode, len(base[i])+len(path))
-			copy(np, base[i])
-			copy(np[len(base[i]):], path)
-			stack.SetPath(np)
+			for _, stack := range group {
+				path := stack.Path()
+				np := make([]interfaces.StackNode, len(base)+len(path))
+				copy(np, base)
+				copy(np[len(base):], path)
+				stack.SetPath(np)
+			}
 		}
 	})
 }
 
 func (f *WithBaseDecorator) logBaseInfo(g *groups) {
-	if f.Verbose > 1 {
-		log.Printf("all stacks are grouped into %d groups by base nodes (depth=%d)", len(g.G), f.BaseCount)
-	}
-	if f.Verbose > 2 {
-		for i, count := range g.Count {
-			if count > 0 {
-				log.Printf("\t%d samples counted %d base nodes", count, i)
-			}
-		}
+	if f.Verbose > 0 {
+		log.Printf("all stacks are grouped into %d groups by base nodes (depth=%d)", len(g.Base), f.BaseCount)
 	}
 }

--- a/core/guess/guess_fixer.go
+++ b/core/guess/guess_fixer.go
@@ -141,9 +141,6 @@ func computeJoint(path *computePath, stacks []*computePath) {
 		if stack.JoinGroup == path.CurrentIdx {
 			continue
 		}
-		if stack.Group() != path.Group() {
-			continue
-		}
 		begin, length := maxOverlappingMiddleRange(currentStack, stack.Path())
 		if length > path.joint.Overlaps {
 			path.JoinPathIdx = stack.CurrentIdx

--- a/core/interfaces/extra.go
+++ b/core/interfaces/extra.go
@@ -2,17 +2,11 @@ package interfaces
 
 type Extra interface {
 	Needed
-	Grouped
 }
 
 type Needed interface {
 	NeedFix() bool
 	SetNeedFix(need bool)
-}
-
-type Grouped interface {
-	Group() int     // stack belonging to different group won't join each other.
-	SetGroup(g int) // set stack group. stack belonging to different group won't join each other.
 }
 
 // NewStackExtraInfo creates a StackExtraInfo with all field to the correct default value.
@@ -26,15 +20,6 @@ func NewStackExtraInfo() *StackExtraInfo {
 // the details, they just need to embed the type to themselves.
 type StackExtraInfo struct {
 	need  bool
-	group int
-}
-
-func (s *StackExtraInfo) Group() int {
-	return s.group
-}
-
-func (s *StackExtraInfo) SetGroup(g int) {
-	s.group = g
 }
 
 func (s *StackExtraInfo) NeedFix() bool {


### PR DESCRIPTION
Fix bugs in trie: 

> Originally, we visit all list by visiting all leaf nodes (without children). But in this way some stacks will be missing due to this problem. For example, 2 stack `[e1, e2, e3]` and `[e1, e2, e3, e4]` are added to the prefix tree, then we can not get the `[e1, e2, e3]` stack by visiting all leaf nodes with the original method, since the `e3` node in the prefix tree will have children (`{e4}`). 
>
> Now, we change it be mark on the prefix tree nodes, if the node is an end of one stack. Finally we take all nodes with marks to be leaf nodes of the stacks.

Improve code structure for `WithBaseDecorator`

> `WithBaseDecorator` will be able to ignore all non-stack base nodes for guessing stack roots. And stacks with different nodes should not join with each other, so we group all the stacks by the base nodes, and fix each group of stacks respectively to match this rule.

Improve code structure of decorators

> decorators comes early in the decorator chain will be outer decorators in the final result.