### PR TITLE
truncate output file before writing data to avoid broken result

### DIFF
--- a/guess-fold/main.go
+++ b/guess-fold/main.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 
 	"github.com/xnslong/guess-stack/core"
 	"github.com/xnslong/guess-stack/utils"
@@ -20,6 +21,8 @@ func main() {
 }
 
 func FixProfile() {
+	printVersion()
+
 	p := &Profile{}
 	InputProfile(p)
 
@@ -31,6 +34,12 @@ func FixProfile() {
 	})
 
 	OutputProfile(p)
+}
+
+func printVersion() {
+	if *verboseCounter > 0 {
+		log.Printf("program: %s @%s", path.Base(os.Args[0]), core.Version)
+	}
 }
 
 func InputProfile(p *Profile) {

--- a/guess-pprof/flag.go
+++ b/guess-pprof/flag.go
@@ -6,8 +6,6 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const Version = "1.0.1"
-
 var (
 	inputFile = kingpin.Flag("input", "input pprof file. \"-\" means read from the standard input stream").
 			Short('i').

--- a/guess-pprof/main.go
+++ b/guess-pprof/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"io"
 	"log"
+	"os"
+	"path"
 
 	"github.com/xnslong/guess-stack/core"
 	"github.com/xnslong/guess-stack/utils"
@@ -21,6 +23,8 @@ func main() {
 }
 
 func FixProfile() {
+	printVersion()
+
 	p := OpenProfile()
 
 	core.Fix(p, core.FixOption{
@@ -33,12 +37,18 @@ func FixProfile() {
 	WriteProfile(p)
 }
 
+func printVersion() {
+	if *verboseCounter > 0 {
+		log.Printf("program: %s @%s\n", path.Base(os.Args[0]), core.Version)
+	}
+}
+
 func WriteProfile(p *Profile) {
 	err := utils.WriteToFile(*outputFile, func(writer io.Writer) error {
 		return p.WriteTo(writer)
 	})
 	if err != nil {
-		log.Panic("write profile error", err)
+		log.Fatalf("write profile error: %v", err)
 	}
 
 	if *verboseCounter > 0 {
@@ -53,7 +63,7 @@ func OpenProfile() *Profile {
 		return p.ReadFrom(reader)
 	})
 	if err != nil {
-		log.Panic("open profile error", err)
+		log.Fatalf("read profile error: %v", err)
 	}
 
 	if *verboseCounter > 0 {

--- a/utils/io.go
+++ b/utils/io.go
@@ -13,13 +13,13 @@ func WriteToFile(file string, write func(writer io.Writer) error) error {
 	if file == DefaultStream {
 		out = os.Stdout
 	} else {
-		file, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY, 0644)
+		outFile, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return fmt.Errorf("open output file error: %w", err)
 		}
 
-		defer file.Close()
-		out = file
+		defer outFile.Close()
+		out = outFile
 	}
 
 	return write(out)
@@ -30,12 +30,12 @@ func ReadFromFile(file string, read func(reader io.Reader) error) error {
 	if file == DefaultStream {
 		in = os.Stdin
 	} else {
-		file, err := os.OpenFile(file, os.O_RDONLY, 0644)
+		inFile, err := os.OpenFile(file, os.O_RDONLY, 0644)
 		if err != nil {
 			return fmt.Errorf("open input file error: %w", err)
 		}
-		defer file.Close()
-		in = file
+		defer inFile.Close()
+		in = inFile
 	}
 
 	return read(in)


### PR DESCRIPTION
* add `os.O_TRUNC` option on opening output file to truncate the existing contents before write any data to avoid dirty content.